### PR TITLE
Adapt to new w20 structure

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "w20-simple-theme",
-  "version": "3.0.0",
+  "version": "3.1.0-M1",
   "ignore": [
     ".*",
     "*.iml",
@@ -12,6 +12,7 @@
     "package.json"
   ],
   "dependencies": {
-      "w20": "~2.0"
+    "w20": "~2.1",
+    "w20-bootstrap-3": "~2.1"
   }
 }

--- a/modules/menu.js
+++ b/modules/menu.js
@@ -8,7 +8,7 @@ define([
     '[text]!{w20-simple-theme}/templates/topbar.html',
 
     '{angular-sanitize}/angular-sanitize',
-    '{w20-ui}/modules/ui',
+    '{w20-core}/modules/ui',
     '{w20-core}/modules/culture',
     '{w20-core}/modules/utils'
 


### PR DESCRIPTION
Since w20 has been splitted into severall fragments the theme needed some refactoring in its dependencies paths.
